### PR TITLE
Adds DVMega AMBE 3000 support to AMBEtest4.py

### DIFF
--- a/DV3000/AMBEtest4.py
+++ b/DV3000/AMBEtest4.py
@@ -35,7 +35,7 @@ ip_address = "127.0.0.1"
 UDP_PORT = 2460
 
 
-reset = bytearray.fromhex("61 00 01 00 33")
+reset = bytearray.fromhex("61 00 06 00 34 05 00 00 0F 00 00")
 setDstar = bytearray.fromhex("61 00 0d 00 0a 01 30 07 63 40 00 00 00 00 00 00 48")
 getProdId = bytearray.fromhex("61 00 01 00 30")
 getVersion = bytearray.fromhex("61 00 01 00 31")

--- a/DV3000/AMBEtest4.py
+++ b/DV3000/AMBEtest4.py
@@ -35,7 +35,7 @@ ip_address = "127.0.0.1"
 UDP_PORT = 2460
 
 
-reset = bytearray.fromhex("61 00 06 00 34 05 00 00 0F 00 00")
+reset = bytearray.fromhex("61 00 07 00 34 05 00 00 0F 00 00")
 setDstar = bytearray.fromhex("61 00 0d 00 0a 01 30 07 63 40 00 00 00 00 00 00 48")
 getProdId = bytearray.fromhex("61 00 01 00 30")
 getVersion = bytearray.fromhex("61 00 01 00 31")


### PR DESCRIPTION
Changes the 'PKT_RESET' command to use 'PKT_RESETSOFTCFG' + additional bytes, which causes  the AMBE 3000 chip to reset and to ignore the pin configuration for Packet/Codec and DTX_ENABLE.

This has been tested by myself on the DVMega AMBE 3000 and by Flo DF2ET on the ThumbDV